### PR TITLE
added makefile targets for Project Page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,37 @@
 TEX_FILES  =  $(wildcard *.tex)
+BUILD_DIR  = build
 
-all: Nek_users
+all: pdf html
 
-html: $(TEX_FILES)
-	htlatex Nek_users.tex "html,index=1,2,fn-in"
+gh-pages: pdf html
+	cd $(BUILD_DIR) && \
+		git init && \
+		git checkout -b gh-pages && \
+		git add . && \
+		git remote add origin git@github.com:Nek5000/NekDoc.git && \
+		git commit -m "Updating Project Page" && \
+		git push origin gh-pages --force
 
-Nek_users: Nek_users.pdf
+html: $(BUILD_DIR)/Nek_users.html
 
-Nek_users.pdf: $(TEX_FILES)
+$(BUILD_DIR)/Nek_users.html: $(TEX_FILES) | $(BUILD_DIR)
+	htlatex Nek_users.tex "html,index=1,2,fn-in" -cdefault -d$(BUILD_DIR)/
+
+pdf: $(BUILD_DIR)/Nek_users.pdf
+
+$(BUILD_DIR)/Nek_users.pdf: $(TEX_FILES) | $(BUILD_DIR)
 	pdflatex -shell-escape -draftmode Nek_users.tex
 	bibtex Nek_users
 	pdflatex -shell-escape -draftmode Nek_users.tex
-	pdflatex -shell-escape Nek_users.tex
+	pdflatex -shell-escape -output-directory $(BUILD_DIR) Nek_users.tex
 	
 clean:
 	rm -f *~ *.ilg *bak *.idx *.ind *.aux *.toc *.ps *.log *.lof *.loa
 	rm -f *.bbl *.blg *.dvi *.out Nek_users.pdf *.ps  *.los *.lot *.tdo
+	rm -f *.html *.css *.4ct *.4tc *.idv *.lg *.tmp *.xref
+	rm -rf $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir $(BUILD_DIR)
 
 .PHONY: clean 


### PR DESCRIPTION
The Makefile has been updated:
* HTML and PDFs are output to a specified build directory ($BUILD_DIRECTORY)
* A makefile target (gh-pages) will push the build directory to NekDoc/gh-pages

With this workflow, the NekDoc Project Page can be updated by running 'make gh-pages'