### PR TITLE
Added instructions for Git repo in quickstart

### DIFF
--- a/Nek_users.tex
+++ b/Nek_users.tex
@@ -87,9 +87,7 @@ details.
 %\input{code_layout}
 
 \chapter{Quick start}
-\section{Download and Build}
 \input{down_build}
-\section{A worked example}
 \input{example}
 
 \chapter{User files}

--- a/down_build.tex
+++ b/down_build.tex
@@ -2,40 +2,101 @@ This chapter provides a quick overview to using Nek5000
 for some basic flow problems provided in the {\tt .../examples}
 directory.
            
-Nek5000 runs under Linux or any Linux-like OS such as MAC, AIX, BG, Cray etc.  
-The source is maintained in an svn repository and can be downloaded
-from the Nek5000 homepage (google nek5000) or, on linux systems,
-with the svn checkout command:
+Nek5000 runs under Linux or any Linux-like OS such as MAC, AIX, BG, Cray etc.
+The source is maintained in a legacy SVN repository (last updated June 2, 2016)
+and up-to-date Git repositories.  Both repositories are available for
+download, but we recommended that new users work with the Git repositories.  
 
+\section{The Git Repositories}
+
+\subsection{Downloading the source code}
+The Nek5000 source code is hosted on GitHub at \url{https://github.com/Nek5000/Nek5000}.  You can download the source code as a .zip file\footnote{https://github.com/Nek5000/Nek5000/archive/master.zip} or a .tar.gz archive\footnote{https://github.com/Nek5000/Nek5000/archive/master.tar.gz}.  You can also download (or ``clone'') the repository itself.  The following commands will clone the repository in a directory named {\tt \$HOME/Nek5000} (where {\tt \$HOME} denotes your home directory):
 \begin{verbatim}
-svn co https://svn.mcs.anl.gov/repos/nek5 nek5_svn
+cd && git clone https://github.com/Nek5000/Nek5000.git -b master
 \end{verbatim}
-\noindent
-After downloading, build the tools by typing
+You can also clone the repository in any directory of your choice:
 \begin{verbatim}
-cd nek5_svn/trunk/tools
-maketools all
+cd $HOME/my-repos/ && git clone https://github.com/Nek5000/Nek5000.git -b master
 \end{verbatim}
-\noindent
-which will put the tools {\tt genbox, genmap, n2to3, postx,
-prex,} and {\tt pretex} in the top-level {\tt /bin} directory
-(and will create {\tt /bin} if it does not exist).
-It may be necessary to edit the {\tt maketools} file to change 
-the compilers (e.g., to pgf77/pgcc or ifort/icc).  However,
-the default gfortran/gcc is generally fine.
+
+\subsection{Downloading the example problems}
+The Nek5000 example problems are hosted in a second repository on GitHub, \url{https://github.com/Nek5000/NekExamples}.  Likewise, you can download the examples as a .zip archive\footnote{https://github.com/Nek5000/NekExample/archive/master.zip}, a .tar.gz archive\footnote{https://github.com/Nek5000/NekExamples/archive/master.tar.gz}, or you may clone the repository to your home directory:
+\begin{verbatim}
+cd && git clone https://github.com/Nek5000/NekExamples.git -b master
+\end{verbatim}
+or a directory of your choice:
+\begin{verbatim}
+cd $HOME/my-repos/ && git clone https://github.com/Nek5000/Nek5000.git -b master
+\end{verbatim}
+
+\subsection{Tools and scripts}
+
+The {\tt Nek5000/tools} directory contains programs for pre- and
+post-processing tasks, such as generating meshes from geometry descriptions.  The following commands will build the tools in {\tt \$HOME/bin}:
+\begin{verbatim}
+cd Nek5000/tools && ./maketools all
+\end{verbatim}
+By default, the {\tt maketools} script will use gfortran and gcc as the
+Fortran and C compilers; you can specify a different set of compilers by
+editing {\tt maketools}.  You can also build the tools in another
+directory of your choice by providing a second argument to {\tt maketools}; for example:
+\begin{verbatim}
+cd $HOME/my-repos/Nek5000/tools && ./maketools all $HOME/my-tools-bin/
+\end{verbatim}
+
+Besides the compiled tools, there are several convenience scripts in {\tt
+Nek5000/bin} that allow you to easily set up and execute runs of Nek5000.
+These scripts are executable as-is and do not need to be compiled. 
+
+We recommend that you add the paths to the tools and scripts to the {\tt \$PATH}
+variable in your shell's environment.  This will allow you execute the tools
+and scripts without typing the full path to the executables.  In the bash
+shell, if you have cloned Nek5000 in {\tt \$HOME/Nek5000} and compiled tools in
+{\tt \$HOME/bin}, you can edit your executable path with:
+\begin{verbatim}
+export PATH="$HOME/bin:$HOME/Nek5000/bin:$PATH"
+\end{verbatim}
+or if the Nek5000 repository and tools are in custom locations, use:
+\begin{verbatim}
+export PATH="$HOME/my-tools-bin:$HOME/my-repos/Nek5000/bin:$PATH"
+\end{verbatim}
+In the following examples, we will assume that the tools and scripts have been
+added to your {\tt \$PATH}.
+
+\section{The SVN Repository}
+
+\subsection{Downloading the source code and examples}
+
+The SVN repository can be downloaded with the following commands:
+\begin{verbatim}
+cd && svn co https://svn.mcs.anl.gov/repos/nek5 nek5_svn
+\end{verbatim}
+This will create a directoy named {\tt nek5\_svn} in your home directory.  The
+example problems are included in the same SVN repo and do not need to be downloaded separately.
+
+\subsection{Tools and scripts}
+The {\tt nek5\_svn/trunk/tools} directory contains programs for pre- and
+post-processing tasks, such as generating meshes from geometry descriptions.  The following commands will build the tools in {\tt \$HOME/bin}:
+\begin{verbatim}
+cd $HOME/nek5_svn/trunk/tools && ./maketools all
+\end{verbatim}
+By default, the {\tt maketools} script will use gfortran and gcc as the
+Fortran and C compilers; you can specify a different set of compilers by
+editing {\tt maketools}.  
 %\footnote{In some cases it may be necessary to reduce the memory
 %footprint of some of the tools. The procedures are (will be)
 %described in \sc{sec. troubleshooting}.}
 
-In addition to the compiled tools, there are numerous scripts in
-\begin{verbatim}
-nek5_svn/trunk/tools/scripts
-\end{verbatim}
-that are useful to have in the execution path, achieved 
-either by adding this directory to the path or copying its
-contents to the top-level /bin directory.  In the following,
-we assume that scripts such as {\tt nek} and {\tt nekb}
-are in the path.  We further assume that the {\tt nek5\_svn/}
-prefix is implied in any future directory reference, unless
-otherwise specified.
+Besides the compiled tools, there are several convenience scripts in {\tt
+nek5\_svn/trunk/tools/scripts} that allow you to easily set up and execute runs
+of Nek5000.  These scripts are executable as-is and do not need to be compiled. 
 
+We recommend that you append the paths to the tools and scripts to the {\tt \$PATH}
+variable in your shell's environment.  This will allow you execute the tools
+and scripts without typing the full path to the executables.  In the bash
+shell, you can edit your executable path with:
+\begin{verbatim}
+export PATH="$HOME/bin:$HOME/nek5_svn/trunk/tools/scripts:$PATH"
+\end{verbatim}
+In the following examples, we will assume that the tools and scripts have been
+added to your {\tt \$PATH}.

--- a/example.tex
+++ b/example.tex
@@ -1,15 +1,23 @@
-
+\section{A Worked Example}
 As a first example, we consider the eddy problem due to Walsh 
 \footnote{O. Walsh, ``Eddy solutions of the Navier-Stokes equations,''
 {\em The NSE II-Theory and Numerical Methods}, J.G. Heywood, K. Masuda, 
 R. Rautmann, and V.A. Solonikkov, eds., Springer, pp.  306--309 (1992)}.
-To get started, execute the following commands,
+To get started, execute the following commands for the Git repositories:
 \begin{verbatim}
 cd
 mkdir eddy
 cd eddy
-cp ~/nek5_svn/examples/eddy/* .
-cp ~/nek5_svn/trunk/nek/makenek .
+cp $HOME/NekExamples/eddy/* .
+cp $HOME/Nek5000/core/makenek .
+\end{verbatim}
+or the equivalent commands for the SVN repository:
+\begin{verbatim}
+cd
+mkdir eddy
+cd eddy
+cp $HOME/nek5_svn/examples/eddy/* .
+cp $HOME/nek5_svn/trunk/nek/makenek .
 \end{verbatim}
 
 {\bf Modify {\tt makenek}.}


### PR DESCRIPTION
Fixes #9 
The instructions for the Git repo have been added, and the instructions for the SVN repo have also been retained.  