### PR TITLE
Removed the "WHY?"s from the manual

### DIFF
--- a/data_layout.tex
+++ b/data_layout.tex
@@ -48,7 +48,7 @@ Data is laid out as  \(u_{ijk}^e = u(i,j,k,e)\) \\
    enddo
 \end{verbatim}
 
-   which is equivalent but superior (WHY?) to:
+   which is equivalent but superior to:
 
 \begin{verbatim}
    do e=1,nelv
@@ -63,7 +63,7 @@ Data is laid out as  \(u_{ijk}^e = u(i,j,k,e)\) \\
 \end{verbatim}
 
 
-   which is equivalent but vastly superior (WHY?) to:
+   which is equivalent but vastly superior to:
 
 \begin{verbatim}
    do i=1,nx1

--- a/fld_format.tex
+++ b/fld_format.tex
@@ -29,7 +29,7 @@ representation of the number $6.54321$ either in little or big endian.
   2   &3  & \code{ny} & number of coordinates in y direction \\        
   2   &3  & \code{nz} & number of coordinates in z direction \\        
   5   &11 & \code{nelo} & number of elements \\
-  6   &11 & \code{nelgt} & {\color{red} No idea}\\
+  6   &11 & \code{nelgt} & {\color{red} ----}\\
   7   &21 & \code{time}  & time stamp \\
   8   &10 & \code{iostep} & time step\\
   9   &7  & \code{fid0}   & {\color{red} field id}\\


### PR DESCRIPTION
The "WHY"S in the user manual under 3.4 Data Layout in my opinion shouldn't be included in the manual. I believe the why is due to Fortran being column major and the way the memory can be accessed through the indexing scheme. Can we address the "why" as an issue to ensure we properly address it?
