### PR TITLE
Correct formatting for .ini code block

### DIFF
--- a/source/tutorials.rst
+++ b/source/tutorials.rst
@@ -154,7 +154,7 @@ Control parameters
 
 The par (parameter) file for this case is given as
 
-.. code-block:: fortran
+.. code-block:: ini
 
     #
     # nek parameter file


### PR DESCRIPTION
A code block for the .par file was specified as a "fortraon" code block, but this couldn't be parsed with my version of Sphinx and caused a fatal error.  Specifying the block as "ini" (the actual format of a .par file) fixed the error.  