### PR TITLE
Update sphinx version

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -25,7 +25,7 @@
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '1.8.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -178,4 +178,5 @@ epub_copyright = copyright
 epub_exclude_files = ['search.html']
 
 def setup(app):
-  app.add_stylesheet('css/custom.css')
+#  app.add_stylesheet('css/custom.css') # older API
+  app.add_css_file('css/custom.css')

--- a/source/conf.py
+++ b/source/conf.py
@@ -25,7 +25,7 @@
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = '1.8.0'
+needs_sphinx = '1.8'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
Per https://github.com/sphinx-doc/sphinx/issues/7747, the API has changed to `add_css_file`.
Also add `needs_sphinx = '1.8.0'` just in case.

Tested with
```
$ sphinx-build --version
sphinx-build 7.2.6
```