### PR TITLE
Fix custom CSS inclusion for Sphinx compatibility

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -178,4 +178,7 @@ epub_copyright = copyright
 epub_exclude_files = ['search.html']
 
 def setup(app):
-  app.add_css_file('css/custom.css')
+    try:
+        app.add_stylesheet('css/custom.css')
+    except AttributeError:
+        app.add_css_file('css/custom.css')


### PR DESCRIPTION
Should work from v1.8.0 to recent version.
Tested with v7.2.6.